### PR TITLE
Fix error when running bin/whisk in a clean environment

### DIFF
--- a/bin/whisk
+++ b/bin/whisk
@@ -20,9 +20,7 @@ import subprocess
 import sys
 
 WHISK_DIR = pathlib.Path(__file__).parent.parent
-
-env = os.environ.copy()
-env["PIPENV_PIPFILE"] = (WHISK_DIR / "Pipfile").absolute()
+WHISKPIP = WHISK_DIR / "bin" / "whiskpip"
 
 # Check if the virtual environment is available. This isn't a perfect check
 # because the environment could be created but not synced, but the user would
@@ -30,23 +28,23 @@ env["PIPENV_PIPFILE"] = (WHISK_DIR / "Pipfile").absolute()
 # that way.
 if (
     subprocess.run(
-        ["pipenv", "--venv"],
-        env=env,
+        [WHISKPIP, "--venv"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.STDOUT,
     ).returncode
     != 0
 ):
-    subprocess.run(["pipenv", "sync", "--bare"], env=env, check=True)
+    if not (WHISK_DIR / "Pipfile.lock").exists():
+        subprocess.run([WHISKPIP, "lock"], check=True)
+    subprocess.run([WHISKPIP, "sync", "--bare"], check=True)
 
-os.execvpe(
-    "pipenv",
+os.execv(
+    WHISKPIP,
     [
-        "pipenv",
+        pathlib.Path(__file__).name,
         "run",
         "--",
         (WHISK_DIR / "whisk.py").absolute(),
     ]
     + sys.argv[1:],
-    env,
 )

--- a/bin/whiskpip
+++ b/bin/whiskpip
@@ -1,0 +1,24 @@
+#! /usr/bin/env python3
+#
+# 2020 Garmin Ltd. or its subsidiaries
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+import sys
+
+env = os.environ.copy()
+env["PIPENV_PIPFILE"] = (pathlib.Path(__file__).parent.parent / "Pipfile").absolute()
+
+os.execvpe("pipenv", ["pipenv"] + sys.argv[1:], env)

--- a/ci/test.py
+++ b/ci/test.py
@@ -128,6 +128,32 @@ class WhiskExampleConfTests(unittest.TestCase):
         )
 
 
+class WhiskEnvSetupTests(unittest.TestCase):
+    def test_lock_setup(self):
+        lock_file = ROOT / "Pipfile.lock"
+
+        subprocess.run(
+            [ROOT / "bin" / "whiskpip", "--rm"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            os.unlink(lock_file)
+        except FileNotFoundError:
+            pass
+
+        p = subprocess.run(
+            [ROOT / "bin" / "whisk", "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(
+            p.returncode, 0, "Command failed with:\n%s" % p.stdout.decode("utf-8")
+        )
+
+        self.assertTrue(lock_file.exists(), "Lock file %s not created!" % lock_file)
+
+
 class WhiskConfParseTests(WhiskTests, unittest.TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Since a Pipfile.lock is no longer included in the repository, "pipenv
lock" must be run to create one before synchronizing the packages.