### PR TITLE
Remove use of _append

### DIFF
--- a/whisk.py
+++ b/whisk.py
@@ -519,7 +519,7 @@ def configure(sys_args):
                     BBMULTICONFIG = "{multiconfigs}"
                     BBMASK += "${{BBMASK_${{WHISK_PRODUCT}}}}"
 
-                    BB_HASHBASE_WHITELIST_append = " WHISK_PROJECT_ROOT"
+                    BB_HASHBASE_WHITELIST += "WHISK_PROJECT_ROOT"
                     """
                 ).format(multiconfigs=" ".join(sorted(multiconfigs)))
             )


### PR DESCRIPTION
_append is not compatible with Yocto 3.4 (honister) because the syntax
for variable overrides has changed. Fortunately, there is only one
location where the old style of override was being used and it can
easily be converted to use += instead