### PR TITLE
Fix relative invocation of bin/whisk

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -38,6 +38,10 @@ class WhiskTests(object):
         cleanup_project()
         self.project_root.mkdir(parents=True)
 
+        oldcwd = os.getcwd()
+        os.chdir(self.project_root)
+        self.addCleanup(os.chdir, oldcwd)
+
         os.symlink(ROOT / "init-build-env", self.project_root / "init-build-env")
 
         self.conf_file = self.project_root / "whisk.yaml"
@@ -125,6 +129,28 @@ class WhiskExampleConfTests(unittest.TestCase):
         )
         self.assertEqual(
             p.returncode, 0, "Validation failed with:\n%s" % p.stdout.decode("utf-8")
+        )
+
+
+class WhiskCommandTests(WhiskTests, unittest.TestCase):
+    def test_relative_invocation(self):
+        p = subprocess.run(
+            [os.path.relpath(ROOT / "bin" / "whisk", self.project_root), "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(
+            p.returncode, 0, "Unable to invoke whisk:\n%s" % p.stdout.decode("utf-8")
+        )
+
+    def test_absolute_invocation(self):
+        p = subprocess.run(
+            [ROOT / "bin" / "whisk", "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(
+            p.returncode, 0, "Unable to invoke whisk:\n%s" % p.stdout.decode("utf-8")
         )
 
 

--- a/setup-venv
+++ b/setup-venv
@@ -17,16 +17,15 @@
 set -eu
 
 THIS_DIR="$(dirname $0)"
-VENV_DIR="$THIS_DIR/venv"
 
 cd $THIS_DIR
 
 REV="$(git rev-parse HEAD):$(shasum "requirements.txt")"
 
-if [ ! -e "$VENV_DIR/rev.txt" ] || [ "$(cat $VENV_DIR/rev.txt)" != "$REV" ]; then
-    python3 -m venv "$VENV_DIR"
-    . "$VENV_DIR/bin/activate"
+if [ ! -e "venv/rev.txt" ] || [ "$(cat venv/rev.txt)" != "$REV" ]; then
+    python3 -m venv "venv"
+    . "venv/bin/activate"
     pip install -r requirements.txt
-    echo "$REV" > "$VENV_DIR/rev.txt"
+    echo "$REV" > "venv/rev.txt"
 fi
 


### PR DESCRIPTION
Invoking bin/whisk from any working directory other than the root of the
whisk repo was broken because the path to the virtual environment was
wrong after the chdir