### PR TITLE
Add Yocto 4.0 (kirkstone) support

### DIFF
--- a/meta-whisk/conf/layer.conf
+++ b/meta-whisk/conf/layer.conf
@@ -11,5 +11,5 @@ BBFILE_COLLECTIONS += "whisk"
 BBFILE_PATTERN_whisk = "^${LAYERDIR}/"
 BBFILE_PRIORITY_whisk = "6"
 
-LAYERSERIES_COMPAT_whisk = "zeus dunfell gatesgarth hardknott"
+LAYERSERIES_COMPAT_whisk = "zeus dunfell gatesgarth hardknott kirkstone"
 

--- a/whisk.example.yaml
+++ b/whisk.example.yaml
@@ -51,6 +51,10 @@ hooks:
   post_init: |
     # placeholder
 
+  # A list of environment variables to pass through to bitbake (e.g.
+  # BB_ENV_EXTRAWHITE/BB_ENV_PASSTHROUGH_ADDITIONS)
+  env_passthrough_vars: []
+
 # Commands to run if the user specifies --fetch to fetch layers.
 #
 # Fetch commands are always run with the current working directory set to the
@@ -69,6 +73,12 @@ versions:
   dunfell:
     # a short description of the version (optional)
     description: Yocto 3.1
+
+    # What Yocto release this version is compatible with, as the codename of
+    # the release (e.g. "zeus", "dunfell", "gatesgarth", etc.). If set to
+    # "auto" (the default if unspecified), whisk will scan all layers in this
+    # version to try and automatically figure out an appropriate version
+    compat: auto
 
     # The path to the OE initialization script for this version
     oeinit: "%{WHISK_PROJECT_ROOT}/layers/dunfell/poky/oe-init-build-env"

--- a/whisk.schema.json
+++ b/whisk.schema.json
@@ -59,6 +59,12 @@
                 "pre_init": {
                     "type": "string"
                 },
+                "env_passthrough_vars": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "post_init": {
                     "type": "string"
                 }
@@ -80,6 +86,9 @@
                             "type": "string"
                         },
                         "oeinit": {
+                            "type": "string"
+                        },
+                        "compat": {
                             "type": "string"
                         },
                         "fetch": {


### PR DESCRIPTION
In order to correctly handle the quirks of various different Yocto
versions (and importantly Yocto 4.0), a table of supported version with
their discrepancies has been added. A version in the whisk.yaml file can
specify which Yocto version it is compatible with in a number of ways:
 * Explicitly specifying the release name the version is compatible with
   in its "compat" property
 * Specifying "auto" for its "compat" property. Whisk will scan all
   includes layer.conf files until it finds LAYERSERIES_CORENAMES (set
   in OE-core) uses it as the compatible version
 * Omitting the "compat" property, in which case it defaults to "auto"

In addition, a new property called `env_passthrough_vars` is added to
the `hooks` section. This controls what environment variables from the
host are passed in to bitbake; this is required so that the correct
environment variable can be used to pass these variables along based on
the compat version.

Finally, whisk now takes responsibility for setting CONF_VERSION in the
config file it writes out, so if you were setting that manually before
it needs to be removed.