### PR TITLE
Add ability to disable using a python venv to run whisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,17 @@ OpenEmbedded and the Yocto project. The key features are:
 ## Requirements
 
 Whisk is primarily written in Python, with a small initialization shell script
-to setup the build environment. The Python code runs under
+to setup the build environment. By default, the Python code runs under
 [virtualenv](https://virtualenv.pypa.io/en/latest/) and the initialization
 script will use it to automatically install the required dependencies. See the
 virtualenv documentation for installation instructions.
+
+If you wish to avoid the usage of virtualenv, for instance because you run the
+initialization shell script in a restricted environment where downloading
+dependencies is not possible, you may set the `WHISK_NO_VENV` environment
+variable. The value does not matter, only that it is set. In that case, you
+yourself must ensure that the required dependencies are available. See
+[requirements.txt](/requirements.txt) for the list of dependencies.
 
 [Using Whisk]: #using-whisk
 ## Using Whisk

--- a/bin/whisk
+++ b/bin/whisk
@@ -14,6 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
 THIS_DIR="$(dirname $0)"
-exec "$THIS_DIR/whiskenv" "$THIS_DIR/../whisk.py" "$@"
+WHISKENV="$THIS_DIR/whiskenv"
+
+if [ ! -z "${WHISK_NO_VENV}" ]; then
+    echo "Not using python venv, make sure you have the necessary packages installed as system packages."
+    set -eu
+    exec "$THIS_DIR/../whisk.py" "$@"
+else
+    set -eu
+    exec ${WHISKENV} "$THIS_DIR/../whisk.py" "$@"
+fi


### PR DESCRIPTION
In some scenarios it's undesirable to have a requirement on python virtual environments and using pip to download dependencies at on-demand, for instance when building in a restricted CI environment.

This change let's users set the WHISK_NO_VENV shell variable to prevent the usage of python virtual environment and pip to install python dependencies required by whisk.py. The user must then make sure that these dependencies are available some other way, for instance by installing them via the system's native package manager.