### PR TITLE
requirements: keep python 3.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ jsonschema==3.2.0; python_version < '3.7'
 jsonschema==4.17.3; python_version >= '3.7'
 tabulate==0.8.10; python_version < '3.7'
 tabulate==0.9.0; python_version >= '3.7'
-tqdm==4.65.0
-yamllint==1.32.0
+tqdm==4.64.1; python_version < '3.7'
+tqdm==4.65.0; python_version >= '3.7'
+yamllint==1.28.0; python_version < '3.7'
+yamllint==1.32.0; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==6.0
 jsonschema==3.2.0; python_version < '3.7'
-jsonschema==4.17.3; python_version > '3.6'
+jsonschema==4.17.3; python_version >= '3.7'
 tabulate==0.9.0
 tqdm==4.65.0
 yamllint==1.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==6.0
 jsonschema==3.2.0; python_version < '3.7'
-jsonschema==4.17.3
+jsonschema==4.17.3; python_version > '3.6'
 tabulate==0.9.0
 tqdm==4.65.0
 yamllint==1.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML==6.0
+jsonschema==3.2.0; python_version < '3.7'
 jsonschema==4.17.3
 tabulate==0.9.0
 tqdm==4.65.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 PyYAML==6.0
 jsonschema==3.2.0; python_version < '3.7'
 jsonschema==4.17.3; python_version >= '3.7'
-tabulate==0.9.0
+tabulate==0.8.10; python_version < '3.7'
+tabulate==0.9.0; python_version >= '3.7'
 tqdm==4.65.0
 yamllint==1.32.0


### PR DESCRIPTION
Updates the dependent python module jsonschema to the latest version supported by Python 3.6 as it doesn't support the newer module version.

Adds Python 3.6 back to the actions check job workflows.