### PR TITLE
add support for python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-PyYAML==6.0
+PyYAML==6.0.1
 jsonschema==3.2.0; python_version < '3.7'
-jsonschema==4.17.3; python_version >= '3.7'
+jsonschema==4.20.0; python_version >= '3.7'
 tabulate==0.8.10; python_version < '3.7'
 tabulate==0.9.0; python_version >= '3.7'
 tqdm==4.64.1; python_version < '3.7'


### PR DESCRIPTION
Sourcing the init-build-env script fails when using python 3.12:

`"../repositories/yocto/whisk/bin/../whisk.py", line 20, in <module> import jsonschema ModuleNotFoundError: No module named 'jsonschema'`

This PR add support for Py3.12:

Update PyYAML to 6.0.1
Update jsonschema to 4.20.0