### PR TITLE
Improve init-build-env script to be more portable

### DIFF
--- a/init-build-env
+++ b/init-build-env
@@ -52,7 +52,7 @@ configure() {
 			-- "$@"
 	local ERR=$?
 
-	if [ "$WHISK_CAPTURE_ENV" == "-" ]; then
+	if [ "$WHISK_CAPTURE_ENV" = "-" ]; then
 		cat $TEMP_ENV_FILE
 	elif [ -n "$WHISK_CAPTURE_ENV" ]; then
 		cat $TEMP_ENV_FILE > "$WHISK_CAPTURE_ENV"


### PR DESCRIPTION
The `==` is not POSIX compatible, so changed it to `=`