### PR TITLE
Add support for newer Yocto Project releases

### DIFF
--- a/meta-whisk/conf/layer.conf
+++ b/meta-whisk/conf/layer.conf
@@ -22,4 +22,7 @@ LAYERSERIES_COMPAT_whisk = "\
     langdale \
     nanbield \
     scarthgap \
+    styhead \
+    walnascar \
+    whinlatter \
     "


### PR DESCRIPTION
Add styhead, walnascar, and whinlatter to LAYERSERIES_COMPAT in meta-whisk.