### PR TITLE
Remove multi-product build support

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -169,8 +169,7 @@ class WhiskConfParseTests(WhiskTests, unittest.TestCase):
             """
             version: 2
             defaults:
-                products:
-                - test-dunfell
+                product: test-dunfell
                 mode: mode
                 site: site
 
@@ -251,8 +250,7 @@ class WhiskConfParseTests(WhiskTests, unittest.TestCase):
             """
             version: 2
             defaults:
-                products:
-                - test-dunfell
+                product: test-dunfell
                 mode: mode
                 site: site
 
@@ -292,8 +290,7 @@ class WhiskConfParseTests(WhiskTests, unittest.TestCase):
             ---
             version: 2
             defaults:
-                products:
-                - test-dunfell
+                product: test-dunfell
                 mode: mode
                 site: site
 
@@ -681,35 +678,6 @@ class WhiskVersionTests(WhiskTests, unittest.TestCase):
             },
         )
 
-        self.assertShellCode(
-            """\
-            . init-build-env --product=test-dunfell --product=test-zeus --version=zeus
-            """,
-            {
-                "WHISK_VERSION": "zeus",
-                "WHISK_ACTUAL_VERSION": "zeus",
-            },
-        )
-
-    def test_mixed_product_implicit_default(self):
-        # Mixing products with different versions using an implicit default
-        # should fail
-        self.assertShellCode(
-            """\
-            . init-build-env --product=test-dunfell --product=test-zeus
-            """,
-            success=False,
-        )
-
-    def test_mixed_product_explicit_default(self):
-        # Different version products with explicit default should fail
-        self.assertShellCode(
-            """\
-            . init-build-env --product=test-dunfell --product=test-zeus --version=default
-            """,
-            success=False,
-        )
-
     def test_changing_compatible_version_when_default(self):
         # Changing to a product with the same version after configuring
         self.assertShellCode(
@@ -981,34 +949,13 @@ class WhiskInitTests(WhiskTests, unittest.TestCase):
             success=False,
         )
 
-    def test_multiple_products_joined(self):
-        self.assertShellCode(
-            """\
-            . init-build-env --products="test-dunfell test-zeus" --version=dunfell --mode=modeA --site=siteA
-            """,
-            {
-                "WHISK_PRODUCTS": "test-dunfell test-zeus",
-            },
-        )
-
-    def test_multiple_products_split(self):
-        self.assertShellCode(
-            """\
-            . init-build-env --product=test-dunfell --product=test-zeus --version=dunfell --mode=modeA --site=siteA
-            """,
-            {
-                "WHISK_PRODUCTS": "test-dunfell test-zeus",
-            },
-        )
-
     def test_defaults(self):
         self.append_conf(
             """\
             defaults:
                 mode: modeA
                 site: siteA
-                products:
-                - test-dunfell
+                product: test-dunfell
             """
         )
 
@@ -1053,8 +1000,7 @@ class WhiskInitTests(WhiskTests, unittest.TestCase):
             defaults:
                 mode: modeA
                 site: siteA
-                products:
-                - test-dunfell
+                product: test-dunfell
             """
         )
 
@@ -1138,8 +1084,7 @@ class WhiskNonMulticonfigTests(WhiskTests, unittest.TestCase):
             defaults:
                 mode: modeA
                 site: siteA
-                products:
-                - test-non-mc1
+                product: test-non-mc1
 
             """.format(
                 ROOT=ROOT
@@ -1151,26 +1096,6 @@ class WhiskNonMulticonfigTests(WhiskTests, unittest.TestCase):
         self.assertShellCode(
             """\
             . init-build-env --product=test-non-mc1
-            """,
-            success=True,
-        )
-
-    def test_multiple_non_multiconfig_products(self):
-        # Attempting to use two non-multiconfig products at the same time
-        # should fail.
-        self.assertShellCode(
-            """\
-            . init-build-env --product=test-non-mc1 --product=test-non-mc2
-            """,
-            success=False,
-        )
-
-    def test_multiple_multiconfig_products(self):
-        # Attempting to use any multiconfig product in conjunction with a
-        # non-multiconfig product should fail.
-        self.assertShellCode(
-            """\
-            . init-build-env --product=test-mc1 --product=test-mc2
             """,
             success=True,
         )
@@ -1249,67 +1174,6 @@ class WhiskBbmaskTests(WhiskTests, unittest.TestCase):
 
     def assertNotInBbconf(self, line):
         self.assertNotIn(line, self.readBbconfLines())
-
-    def test_layer_bbmask(self):
-        # Check that the basic formulation of per-product masks for layer
-        # collections is working.
-        self.assertShellCode(
-            """\
-            . init-build-env --product=using-collection1 --product=using-collection2
-            """,
-            success=True,
-        )
-
-        self.assertInBbconf(
-            'BBMASK_using-collection1 += "{PROJECT_ROOT}/layers/meta-layer2"\n'.format(
-                PROJECT_ROOT=self.project_root
-            )
-        )
-        self.assertInBbconf(
-            'BBMASK_using-collection2 += "{PROJECT_ROOT}/layers/meta-layer1"\n'.format(
-                PROJECT_ROOT=self.project_root
-            )
-        )
-        self.assertNotInBbconf(
-            'BBMASK_using-collection1 += "{PROJECT_ROOT}/layers/meta-layer1"\n'.format(
-                PROJECT_ROOT=self.project_root
-            )
-        )
-        self.assertNotInBbconf(
-            'BBMASK_using-collection2 += "{PROJECT_ROOT}/layers/meta-layer2"\n'.format(
-                PROJECT_ROOT=self.project_root
-            )
-        )
-
-    def test_active_layer_collection_bbmask(self):
-        # Check that laye-specific bbmasks are applied on the product using the layers.
-        self.assertShellCode(
-            """\
-            . init-build-env --product=using-collection1 --product=using-collection2
-            """,
-            success=True,
-        )
-
-        self.assertInBbconf(
-            'BBMASK_using-collection2 += "{PROJECT_ROOT}/layers/meta-layer2/recipes-bad/bad.bb"\n'.format(
-                PROJECT_ROOT=self.project_root
-            )
-        )
-
-    def test_inactive_layer_collection_bbmask(self):
-        # Check that laye-specific bbmasks are applied on the product using the layers.
-        self.assertShellCode(
-            """\
-            . init-build-env --product=using-collection1 --product=using-collection2
-            """,
-            success=True,
-        )
-
-        self.assertNotInBbconf(
-            'BBMASK_using-collection1 += "{PROJECT_ROOT}/layers/meta-layer2/recipes-bad/bad.bb"\n'.format(
-                PROJECT_ROOT=self.project_root
-            )
-        )
 
 
 if __name__ == "__main__":

--- a/whisk.py
+++ b/whisk.py
@@ -175,8 +175,8 @@ def print_sites(conf, cur_site):
     print_items(conf["sites"], lambda s: s == cur_site)
 
 
-def print_products(conf, cur_products):
-    print_items(conf["products"], lambda p: p in cur_products)
+def print_products(conf, cur_product):
+    print_items(conf["products"], lambda p: p == cur_product)
 
 
 def print_versions(conf, cur_version):
@@ -244,9 +244,7 @@ def parse_conf_file(path):
 
 def configure(sys_args):
     parser = argparse.ArgumentParser(description="Configure build")
-    parser.add_argument(
-        "--products", action="append", default=[], help="Change build product(s)"
-    )
+    parser.add_argument("--product", help="Change build product")
     parser.add_argument("--mode", help="Change build mode")
     parser.add_argument("--site", help="Change build site")
     parser.add_argument("--version", help="Set Yocto version")
@@ -299,7 +297,7 @@ def configure(sys_args):
     defaults = conf.get("defaults", {})
 
     cur_mode = cache.get("mode", defaults.get("mode"))
-    cur_products = cache.get("products", defaults.get("products", []))
+    cur_product = cache.get("product", defaults.get("product"))
     cur_site = cache.get("site", defaults.get("site"))
     cur_version = cache.get("version", "default")
     cur_actual_version = cache.get("actual_version", "")
@@ -309,7 +307,7 @@ def configure(sys_args):
 
     if user_args.list:
         print("Possible products:")
-        print_products(conf, cur_products)
+        print_products(conf, cur_product)
         print("Possible modes:")
         print_modes(conf, cur_mode)
         print("Possible sites:")
@@ -318,17 +316,13 @@ def configure(sys_args):
         print_versions(conf, cur_version)
         return 0
 
-    if user_args.products:
+    if user_args.product:
         write = True
-        user_products = sorted(
-            set(itertools.chain(*(a.split() for a in user_args.products)))
-        )
-        for p in user_products:
-            if not p in conf.get("products", {}):
-                print("Unknown product '%s'. Please choose from:" % p)
-                print_products(conf, cur_products)
-                return 1
-        cur_products = user_products
+        if not user_args.product in conf.get("products", {}):
+            print("Unknown product '%s'. Please choose from:" % user_args.product)
+            print_products(conf, cur_product)
+            return 1
+        cur_product = user_args.product
 
     if user_args.mode:
         write = True
@@ -374,8 +368,8 @@ def configure(sys_args):
             return 1
         build_dir = pathlib.Path(user_args.build_dir)
 
-    if not cur_products:
-        print("One or more products must be specified with --product")
+    if not cur_product:
+        print("A product must be specified with --product")
         return 1
 
     if not cur_mode:
@@ -388,39 +382,21 @@ def configure(sys_args):
 
     # Set the actual version
     if cur_version == "default":
-        product_versions = {}
+        product_version = conf["products"][cur_product]["default_version"]
 
-        for p in cur_products:
-            v = conf["products"][p]["default_version"]
-            product_versions.setdefault(v, []).append(p)
-
-        keys = list(product_versions)
-        if len(keys) == 1:
-            if sys_args.init or keys[0] == cur_actual_version:
-                # Environment hasn't been initialized or it's not changing, so
-                # it can be set
-                cur_actual_version = keys[0]
-            else:
-                print(
-                    "Build environment is configured to build version '{actual}' and cannot be changed to version '{v}' required to build products: {products}. Please initialize a new environment with `--product='{products}' --version=default`".format(
-                        actual=cur_actual_version,
-                        v=keys[0],
-                        products=" ".join(product_versions[keys[0]]),
-                    )
-                )
-                return 1
+        if sys_args.init or product_version == cur_actual_version:
+            # Environment hasn't been initialized or it's not changing, so
+            # it can be set
+            cur_actual_version = product_version
         else:
             print(
-                "Multiple products with different default versions were chosen. They are:"
-            )
-            print(
-                tabulate.tabulate(
-                    [(k, " ".join(v)) for k, v in product_versions.items()],
-                    tablefmt="plain",
+                "Build environment is configured to build version '{actual}' and cannot be changed to version '{v}' required to build products: {product}. Please initialize a new environment with `--product={product} --version=default`".format(
+                    actual=cur_actual_version,
+                    v=product_version,
+                    product=cur_product,
                 )
             )
             return 1
-
     else:
         cur_actual_version = cur_version
 
@@ -433,33 +409,21 @@ def configure(sys_args):
         l["name"]: l.get("bbmask", []) for l in version.get("layers", [])
     }
 
-    using_multiconfig = True
-
     # Sanity check that if any selected product does not support multiconfig,
     # it is the only selected product.
-    for p in cur_products:
-        if not conf["products"][p].get("multiconfig_enabled", True):
-            using_multiconfig = False
-
-            if len(cur_products) > 1:
-                print(
-                    "Product '{product}' does not support multiconfig, but more than one product is chosen.".format(
-                        product=p
-                    )
+    using_multiconfig = conf["products"][cur_product].get("multiconfig_enabled", True)
+    if not using_multiconfig:
+        multiconfigs = conf["products"][cur_product].get("multiconfigs", [])
+        if len(multiconfigs) > 0:
+            print(
+                "Product '{product}' does not support multiconfig, but its 'multiconfig' attribute has some elements: {multiconfigs}.".format(
+                    product=cur_product, multiconfigs=multiconfigs
                 )
-                return 1
-
-            multiconfigs = conf["products"][p].get("multiconfigs", [])
-            if len(multiconfigs) > 0:
-                print(
-                    "Product '{product}' does not support multiconfig, but its 'multiconfig' attribute has some elements: {multiconfigs}.".format(
-                        product=p, multiconfigs=multiconfigs
-                    )
-                )
-                return 1
+            )
+            return 1
 
     # Sanity check that all configured products have layers
-    for p in ["core"] + cur_products:
+    for p in ["core", cur_product]:
         missing = set(
             l for l in get_product(p).get("layers", []) if not l in cur_layers_paths
         )
@@ -472,7 +436,7 @@ def configure(sys_args):
             return 1
 
     requested_layers = set()
-    for name in ["core"] + cur_products:
+    for name in ["core", cur_product]:
         requested_layers.update(get_product(name).get("layers", []))
 
     if user_args.fetch:
@@ -525,7 +489,7 @@ def configure(sys_args):
         f.write(
             textwrap.dedent(
                 f"""\
-                export WHISK_PRODUCTS="{' '.join(cur_products)}"
+                export WHISK_PRODUCTS="{cur_product}"
                 export WHISK_MODE="{cur_mode}"
                 export WHISK_SITE="{cur_site}"
                 export WHISK_VERSION="{cur_version}"
@@ -594,7 +558,7 @@ def configure(sys_args):
                     {
                         "cache_version": CACHE_VERSION,
                         "mode": cur_mode,
-                        "products": cur_products,
+                        "product": cur_product,
                         "site": cur_site,
                         "version": cur_version,
                         "actual_version": cur_actual_version,
@@ -657,39 +621,38 @@ def configure(sys_args):
                     """
                 )
             )
-            f.write(
-                'WHISK_TARGETS_core = "%s"\n'
-                % (" ".join("${WHISK_TARGETS_%s}" % p for p in cur_products))
-            )
+            f.write('WHISK_TARGETS_core = "${WHISK_TARGETS_%s}"\n' % cur_product)
 
-            for p in sorted(conf["products"]):
-                if conf["version"] < 2:
-                    f.write(
-                        'DEPLOY_DIR_{p} = "${{WHISK_DEPLOY_DIR_{p}}}"\n'.format(p=p)
-                    )
-
+            if conf["version"] < 2:
                 f.write(
-                    textwrap.dedent(
-                        """\
-                        WHISK_DEPLOY_DIR_{p} = "${{WHISK_DEPLOY_DIR_BASE}}/{p}"
-                        WHISK_TARGETS_{p} = "{targets}"
-                        """
-                    ).format(
-                        p=p,
-                        targets=" ".join(
-                            sorted(conf["products"][p].get("targets", []))
-                        ),
+                    'DEPLOY_DIR_{p} = "${{WHISK_DEPLOY_DIR_{p}}}"\n'.format(
+                        p=cur_product
                     )
                 )
+
+            f.write(
+                textwrap.dedent(
+                    """\
+                    WHISK_DEPLOY_DIR_{p} = "${{WHISK_DEPLOY_DIR_BASE}}/{p}"
+                    WHISK_TARGETS_{p} = "{targets}"
+                    """
+                ).format(
+                    p=cur_product,
+                    targets=" ".join(
+                        sorted(conf["products"][cur_product].get("targets", []))
+                    ),
+                )
+            )
 
             f.write("\n")
 
             # Only set up Bitbake multiconfig if the selected Whisk products
             # support it.
             if using_multiconfig:
-                multiconfigs = set("product-%s" % p for p in cur_products)
-                for p in cur_products:
-                    multiconfigs |= set(conf["products"][p].get("multiconfigs", []))
+                multiconfigs = set(
+                    conf["products"][cur_product].get("multiconfigs", [])
+                )
+                multiconfigs.add("product-%s" % cur_product)
 
                 f.write(
                     textwrap.dedent(
@@ -699,7 +662,6 @@ def configure(sys_args):
                     ).format(multiconfigs=" ".join(sorted(multiconfigs)))
                 )
 
-            f.write('BBMASK += "${BBMASK_${WHISK_PRODUCT}}"\n')
             f.write(
                 f'{compat.basehash_ignore_vars}{compat.append_sep}append = " WHISK_PROJECT_ROOT"\n'
             )
@@ -715,8 +677,6 @@ def configure(sys_args):
             # in Whisk's conf/multiconfig directory, at the very bottom
             # of site.conf.
             if not using_multiconfig:
-                assert len(cur_products) == 1
-
                 f.write(
                     textwrap.dedent(
                         """\
@@ -724,7 +684,7 @@ def configure(sys_args):
                         # specific info into base configuration.
                         require conf/multiconfig/product-{product}.conf
                         """
-                    ).format(product=cur_products[0])
+                    ).format(product=cur_product)
                 )
                 f.write("\n")
 
@@ -761,17 +721,6 @@ def configure(sys_args):
                 )
             )
 
-            for name in ["core"] + cur_products:
-                for l, paths in cur_layers_paths.items():
-                    if not l in get_product(name).get("layers", []):
-                        for p in paths:
-                            f.write('BBMASK_%s += "%s"\n' % (name, p))
-                for l, masks in cur_layers_bbmasks.items():
-                    if l in get_product(name).get("layers", []):
-                        for m in masks:
-                            f.write('BBMASK_%s += "%s"\n' % (name, m))
-                f.write("\n")
-
             for l in version.get("layers", []):
                 if l["name"] in requested_layers:
                     for p in l.get("paths", []):
@@ -794,7 +743,7 @@ def configure(sys_args):
         return 0
 
     if not user_args.quiet:
-        print("PRODUCT    = %s" % " ".join(cur_products))
+        print("PRODUCT    = %s" % cur_product)
         print("MODE       = %s" % cur_mode)
         print("SITE       = %s" % cur_site)
         print("VERSION    = %s" % cur_version, end="")

--- a/whisk.schema.json
+++ b/whisk.schema.json
@@ -34,11 +34,8 @@
         "defaults": {
             "type": "object",
             "properties": {
-                "products": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "product": {
+                    "type": "string"
                 },
                 "mode": {
                     "type": "string"


### PR DESCRIPTION
Removes support for configuring the build to support building multiple products simultaneously (i.e. specifying multiple '--product' arguments when configuring). The mechanism by which the worked was configure bblayers to be the superset of all layers needed by all configured products, then have each product multiconfig BBMASK off the layers they didn't need. However, this results in a weird interaction between BBMASK and dynamic layers; specifically a layer that has dynamic layers will include the dynamic recipes, even if the target layer is masked off by the BBMASK. This will frequently result in dangling bbappends (e.g. a bbappend that doesn't apply to anything), and upstream has made all dangling bbappends hard errors with no way to ignore them (since Yocto 5.2). While it maybe possible with convoluted BBMASK settings to make these go away, the multiple product build support in whisk doesn't not appear to be in widespread use, so removing it allows the remove of the BBMASK manipulation.